### PR TITLE
Change wbstats code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ access to World Bank's indicator data. Use the following code to get the women i
 parliament data:
 ```
 library(wbstats)
-WiP <- library(wbstats)
+wip <- wb(indicator = "SG.GEN.PARL.ZS") 
 ```
 
 ### Importing the Raw Data into R


### PR DESCRIPTION
I changed the code line using `wbstats` so that it actually downloads the data.

It's possible to also get it into the same format as the data below by renaming the variables as follows:
```R
wip <- wb(indicator = "SG.GEN.PARL.ZS") %>%
  # get the same names and order as below
  rename(Country.Code = iso3c, Country.Name = country,
         Indicator.Name = indicator, Indicator.Code = indicatorID,
         pctWIip = value, Year = date) %>%
  select(Country.Name, Country.Code, Indicator.Name, Indicator.Code, pctWIip, Year)
```